### PR TITLE
Fix robust parsing of secrets_config in deployment workflow

### DIFF
--- a/.github/workflows/deploy-cloud-functions.yaml
+++ b/.github/workflows/deploy-cloud-functions.yaml
@@ -140,13 +140,15 @@ jobs:
         run: |
           echo "::group::Preparing secrets configuration"
           secrets_config_input="${{ inputs.secrets_config }}"
-          secrets_array=()
-          readarray -t secrets_array <<< "$secrets_config_input"
           
           secrets_output=""
           first_secret=true
 
-          for secret_name in "${secrets_array[@]}"; do
+          # tr -d '\r' to handle CRLF
+          # while read -r to process line by line
+          # xargs to trim whitespace
+          while read -r line; do
+            secret_name=$(echo "$line" | xargs)
             if [ -z "$secret_name" ]; then
               continue
             fi
@@ -159,7 +161,7 @@ jobs:
 
             secrets_output="${secrets_output}${secret_name}=projects/${{ env.SECRETS_PROJECT_FOR_CONSTRUCTION }}/secrets/${secret_name}/versions/latest"
             first_secret=false
-          done
+          done <<< "$(echo "$secrets_config_input" | tr -d '\r')"
           
           echo "formatted_secrets<<EOF" >> "$GITHUB_OUTPUT"
           echo -e "$secrets_output" >> "$GITHUB_OUTPUT"

--- a/misc/fix_secrets_config.md
+++ b/misc/fix_secrets_config.md
@@ -1,0 +1,29 @@
+# Cloud Functions シークレット設定の修正について
+
+## 問題の概要
+GitHub Actions の `secrets_config` 入力に複数行でシークレット名を指定した際、環境によっては以下の要素が混入し、Google Cloud へのデプロイ時にシークレットが正しく認識されない問題が発生していました。
+
+1.  **改行コード (CRLF)**: Windows 環境などで編集された際に、行末に `\r` (キャリッジリターン) が残る。
+2.  **不要な空白**: シークレット名の前後にスペースが含まれる。
+
+これらが混入すると、GCP 側のリソースパスが `.../secrets/SECRET_NAME\r/versions/latest` のようになり、不正なパスとして扱われます。
+
+## 修正内容
+`.github/workflows/deploy-cloud-functions.yaml` の `prep_secrets` ステップにおいて、パース処理を以下のように改善しました。
+
+- **`tr -d '\r'`**: 入力文字列から全てのキャリッジリターンを削除。
+- **`xargs`**: 各シークレット名の前後の空白をトリミング。
+- **堅牢なループ処理**: `while read` を使用し、空行をスキップしながら正確なカンマ区切りリストを構築。
+
+## 修正後の動作
+呼び出し側で以下のように指定しても、正しくパースされます。
+
+```yaml
+secrets_config: |
+  FIREBASE_SERVICE_ACCOUNT
+
+  ANOTHER_SECRET
+```
+
+空行や末尾のスペースは自動的に除去され、以下の形式でデプロイアクションに渡されます：
+`FIREBASE_SERVICE_ACCOUNT=projects/.../latest,ANOTHER_SECRET=projects/.../latest`


### PR DESCRIPTION
Improved the parsing of the `secrets_config` input in `.github/workflows/deploy-cloud-functions.yaml` to handle CRLF and whitespace, ensuring that secret environment variables are correctly applied to Cloud Functions.

Fixes #9

---
*PR created automatically by Jules for task [8434921471568152867](https://jules.google.com/task/8434921471568152867) started by @yananob*