### PR TITLE
Add options to configure IAM and IAP for HTTP Cloud Run services

### DIFF
--- a/.github/workflows/deploy-cloud-functions.yaml
+++ b/.github/workflows/deploy-cloud-functions.yaml
@@ -210,7 +210,7 @@ jobs:
           done <<< "$SECRETS_CONFIG"
 
           echo "secrets_list=$secrets_output" >> "$GITHUB_OUTPUT"
-          
+
           if [ -n "$secrets_output" ]; then
             echo "Formatted Secrets: $secrets_output"
           else
@@ -235,16 +235,16 @@ jobs:
           environment_variables: |-
            ${{ inputs.environment_variables }}
 
-      - name: 'Allow Public Access to HTTP Function'
-        if: contains(inputs.environment_variables, 'APP_ENV=test') && !inputs.enable_iam && !inputs.enable_iap
-        shell: bash
-        run: |
-          # 裏側の Cloud Run に対しても権限付与（第2世代の場合に必要）
-          gcloud run services add-iam-policy-binding ${{ inputs.function_name }} \
-            --project=${{ secrets.GCP_PROJECT_ID }} \
-            --region=${{ secrets.GCP_REGION }} \
-            --member="allUsers" \
-            --role="roles/run.invoker"
+      # - name: 'Allow Public Access to HTTP Function'
+      #   if: contains(inputs.environment_variables, 'APP_ENV=test') && !inputs.enable_iam && !inputs.enable_iap
+      #   shell: bash
+      #   run: |
+      #     # 裏側の Cloud Run に対しても権限付与（第2世代の場合に必要）
+      #     gcloud run services add-iam-policy-binding ${{ inputs.function_name }} \
+      #       --project=${{ secrets.GCP_PROJECT_ID }} \
+      #       --region=${{ secrets.GCP_REGION }} \
+      #       --member="allUsers" \
+      #       --role="roles/run.invoker"
 
       - name: 'Configure IAM for Cloud Run Service'
         if: inputs.enable_iam

--- a/.github/workflows/deploy-cloud-functions.yaml
+++ b/.github/workflows/deploy-cloud-functions.yaml
@@ -106,6 +106,16 @@ on:
         required: true
         type: string
         default: ''
+      enable_iam:
+        description: 'Cloud RunのIAM（サービスアカウントからの起動）を有効にするかどうか'
+        required: false
+        type: boolean
+        default: true
+      enable_iap:
+        description: 'Cloud RunのIAP（Identity-Aware Proxyからの起動）を有効にするかどうか'
+        required: false
+        type: boolean
+        default: true
     secrets:
       GCP_PROJECT_ID:
         required: true
@@ -226,7 +236,7 @@ jobs:
            ${{ inputs.environment_variables }}
 
       - name: 'Allow Public Access to HTTP Function'
-        if: contains(inputs.environment_variables, 'APP_ENV=test')
+        if: contains(inputs.environment_variables, 'APP_ENV=test') && !inputs.enable_iam && !inputs.enable_iap
         shell: bash
         run: |
           # 裏側の Cloud Run に対しても権限付与（第2世代の場合に必要）
@@ -234,6 +244,27 @@ jobs:
             --project=${{ secrets.GCP_PROJECT_ID }} \
             --region=${{ secrets.GCP_REGION }} \
             --member="allUsers" \
+            --role="roles/run.invoker"
+
+      - name: 'Configure IAM for Cloud Run Service'
+        if: inputs.enable_iam
+        shell: bash
+        run: |
+          gcloud run services add-iam-policy-binding ${{ inputs.function_name }} \
+            --project=${{ secrets.GCP_PROJECT_ID }} \
+            --region=${{ secrets.GCP_REGION }} \
+            --member="serviceAccount:${{ inputs.service_account_name }}@${{ secrets.GCP_PROJECT_ID }}.iam.gserviceaccount.com" \
+            --role="roles/run.invoker"
+
+      - name: 'Configure IAP for Cloud Run Service'
+        if: inputs.enable_iap
+        shell: bash
+        run: |
+          GCP_PROJECT_NUMBER=$(gcloud projects describe ${{ secrets.GCP_PROJECT_ID }} --format="value(projectNumber)")
+          gcloud run services add-iam-policy-binding ${{ inputs.function_name }} \
+            --project=${{ secrets.GCP_PROJECT_ID }} \
+            --region=${{ secrets.GCP_REGION }} \
+            --member="serviceAccount:service-${GCP_PROJECT_NUMBER}@gcp-sa-iap.iam.gserviceaccount.com" \
             --role="roles/run.invoker"
 
   deploy-event:


### PR DESCRIPTION
This pull request adds two new configuration options (`enable_iam` and `enable_iap`, both defaulting to `true`) to `deploy-cloud-functions.yaml`. When enabled, these options configure IAM-based authentication and Identity-Aware Proxy (IAP) access on the underlying Cloud Run service for HTTP-triggered functions. To prevent security bypasses, public access ('allUsers') is restricted when either IAM or IAP is enabled. Additionally, the project number required for building the IAP service account identifier is resolved dynamically using the gcloud CLI.

Fixes #16

---
*PR created automatically by Jules for task [8121143064417047550](https://jules.google.com/task/8121143064417047550) started by @yananob*