### PR TITLE
Fix submodule update workflow rebase conflicts

### DIFF
--- a/.github/workflows/update-submodules.yml
+++ b/.github/workflows/update-submodules.yml
@@ -27,12 +27,11 @@ jobs:
           # 【重要】SSL証明書の検証をオフにしてエラーを回避する
           git config --global http.sslVerify false
 
-          # # サブモジュールの最新化
-          # git submodule update --remote --rebase --recursive
           git submodule status | awk '{print $2}' | while read -r sub; do
             echo "=== Processing: $sub ==="
             pushd "$sub"
-            git pull --rebase
+            git fetch origin
+            git rebase -X theirs "origin/$(git rev-parse --abbrev-ref HEAD)"
             popd
           done
 


### PR DESCRIPTION
Update `update-submodules.yml` to fetch origin and run `git rebase -X theirs` when updating submodules, ensuring incoming remote changes take precedence and prevent workflow failure due to merge conflicts.

Fixes #23

---
*PR created automatically by Jules for task [2366594085407227581](https://jules.google.com/task/2366594085407227581) started by @yananob*